### PR TITLE
Added Dockerfile with Node (LTS Alpine) base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:lts-alpine
+LABEL maintainer "Akashdeep Dhar <t0xic0der@fedoraproject.org>"
+COPY . .
+WORKDIR .
+RUN npm install
+ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
Has inexplicable issues that should be resolved before merging.

Following are the warning logs generated while building the image on `npm install` stage.

```
npm WARN squashcord@1.0.0 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.2 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"arm64"})
```

Also, the server is apparently inaccessible and leaves out an empty response when the said port is accessed.

```
ubuntu@ubuntu:~/data/centos-cdrsrv/SquashCord$ docker run -ti -p 8443:8443 t0xic0der/squashcord:23-04-2021-arm64

> squashcord@1.0.0 start /
> node server

Server running on port 8443
^C
```

Actual 8443/TCP is bridged with virtual 8443/TCP here. Do note that an empty response != 404.

Here's an image pushed to DockerHub exclusively for the `arm64` architecture https://hub.docker.com/r/t0xic0der/squashcord which you can quickly access by running `docker run -ti -p 8443:8443 t0xic0der/squashcord:23-04-2021-arm64`.